### PR TITLE
Add Version header

### DIFF
--- a/apples-mode.el
+++ b/apples-mode.el
@@ -4,6 +4,7 @@
 
 ;; Author: tequilasunset <tequilasunset.mac@gmail.com>
 ;; Keywords: AppleScript, languages
+;; Version: 0.0.2
 (defconst apples-mode-version "0.0.2"
   "The Current version of `apples-mode'.")
 


### PR DESCRIPTION
With this fix, the file can be installed using package.el, e.g.
from the convenient packages automatically built by
MELPA (http://melpa.milkbox.net).

The fix is according to the [GNU Emacs Manual](http://www.gnu.org/software/emacs/manual/html_node/elisp/Simple-Packages.html).
