### PR TITLE
Replace use of deprecated cl by cl-lib and its new function names.

### DIFF
--- a/apples-mode.el
+++ b/apples-mode.el
@@ -1,10 +1,13 @@
 ;;; apples-mode.el --- Major mode for editing and executing AppleScript code
 
 ;; Copyright (C) 2011 tequilasunset
-
+;; Updates since March 2021:  Copyright (c) Pierre Rouleau
+;;
 ;; Author: tequilasunset <tequilasunset.mac@gmail.com>
+;; Maintainer: Pierre Rouleau <prouleau001@gmail.com>
+;;
 ;; Keywords: AppleScript, languages
-(defconst apples-mode-version "0.0.2"
+(defconst apples-mode-version "0.0.3a"
   "The Current version of `apples-mode'.")
 
 ;; This program is free software: you can redistribute it and/or modify
@@ -66,7 +69,14 @@
 ;;; Code:
 
 (eval-when-compile
-  (require 'cl-lib))    ; use: cl-labels, cl-every, cl-some, cl-flet
+  (require 'cl-lib))    ; use: cl-labels, cl-every, cl-some, cl-flet,
+;;                      ;      cl-loop, cl-macrolet, cl-destructuring-bind
+;;                      ;      cl-multiple-value-bind
+(eval-when-compile
+  (require 'cl))        ; for `lexical-let'
+                        ;  TODO: replace that and convert
+                        ;  to complete lexical binding everywhere.
+
 
 (require 'easymenu)
 (require 'newcomment)
@@ -131,7 +141,7 @@ the same directory where apples-mode.el is located."
                             "apples-tmp-dir")))))
       (unless (file-directory-p dir)
         (mkdir dir t))
-      (loop for file in (apples-plist-get :tmp-files)
+      (cl-loop for file in (apples-plist-get :tmp-files)
             for tmp = (format "%s/%s.applescript" dir file)
             do
             (set file tmp)
@@ -295,7 +305,7 @@ nothing (nil). See also `apples-end-completion-hl-duration'."
   :group 'apples)
 
 ;; Faces
-(macrolet ((face (name &rest attrs)
+(cl-macrolet ((face (name &rest attrs)
                  `(defface ,(intern (format "apples-%s" name))
                     '((t (,@attrs)))
                     ,(subst-char-in-string ?- ?  (format "Face for %s." name))
@@ -378,7 +388,7 @@ Otherwise delete stored info."
     "tell application \"AppleScript Runner\" to do script \"%s\"" f/s)))
 
 (defun apples-parse-error (result)
-  (destructuring-bind
+  (cl-destructuring-bind
       (err-ov (actual-beg . err-buf)
               &aux err-beg err-end err-type err-msg err-num unknown)
       (values (apples-plist-get :err-ov) (apples-plist-get :run-info))
@@ -417,7 +427,7 @@ also highlight the error region and go to the beginning of it if
       "%" "%%"                          ; %-sequence => %
       (if (= status 1)
           ;; error
-          (multiple-value-bind (unknown beg end type msg num buf ov)
+          (cl-multiple-value-bind (unknown beg end type msg num buf ov)
               (apples-parse-error result)
             ;; -1713
             (when (eq num -1713)
@@ -786,7 +796,7 @@ are skipped.\n
 - Lines whose bol is in string or in comment
 - Comments"
   (save-excursion
-    (loop initially (beginning-of-line)
+    (cl-loop initially (beginning-of-line)
           while (not (bobp))
           do (forward-line -1)
           unless (or (looking-at "\\s-*$")
@@ -862,7 +872,7 @@ whitespaces are deleted."
          (pos (point))
          indent)
     (unless bol-is-in-string
-      (multiple-value-bind
+      (cl-multiple-value-bind
           (cur-col cur-indent cur-lword prev-bol prev-indent
                    prev-lword prev-lstr prev-cchar-p pprev-cchar-p)
           (apples-parse-lines)
@@ -910,7 +920,7 @@ whitespaces are deleted."
   "Toggle indentation."
   (interactive "^")
   (unless (apples-in-string-p (point-at-bol))
-    (multiple-value-bind
+    (cl-multiple-value-bind
         (cur-col cur-indent _1 prev? prev-indent _2 _3 prev-cchar-p pprev-cchar-p)
         (apples-parse-lines)
       (let* ((pos (point))
@@ -932,7 +942,7 @@ whitespaces are deleted."
 
 ;; end completion
 (defconst apples-statements
-  `(,@(loop for word in '("considering" "ignoring" "try" "if"
+  `(,@(cl-loop for word in '("considering" "ignoring" "try" "if"
                           "repeat" "tell" "using terms from")
             collect (cons word word))
     ("with timeout"                  . "timeout"                    )
@@ -948,27 +958,27 @@ whitespaces are deleted."
 (defun apples-parse-statement ()
   "Parse the current statement block and return the values
 \(BOL-WHERE-STATEMENT-STARTS BEG-WORD-OF-STATEMENT END-WORD-OF-STATEMENT)."
-  (destructuring-bind (min count nils &aux bol lstr)
+  (cl-destructuring-bind (min count nils &aux bol lstr)
       (values (point-min) 1 (values nil nil nil))
     (if (apples-in-string/comment-p)
         nils
       (catch 'val
         (save-excursion
           (while (/= (point) min)
-            (catch 'loop
+            (catch 'cl-loop
               (if (null (setq bol (apples-ideal-prev-bol)))
                   (throw 'val nils)
                 (goto-char bol)
                 (setq lstr (apples-line-string))
                 (if (string-match "^end\\>" lstr)
                     (incf count)
-                  (loop for (beg . end) in apples-statements
+                  (cl-loop for (beg . end) in apples-statements
                         when (and (string-match (concat "^" beg "\\>") lstr)
                                   (not (apples-string-match apples-noindent-regexps
                                                             lstr)))
                         do (if (zerop (decf count))
                                (throw 'val (values bol beg end))
-                             (throw 'loop nil))
+                             (throw 'cl-loop nil))
                         finally
                         ;; in case of `on'
                         (when (and (string-match (concat "^on \\("
@@ -986,7 +996,7 @@ whitespaces are deleted."
   "Insert `end + current-statement-name'. If `apples-end-completion-hl' is
 specified, also highlight the matching statement."
   (interactive "^")
-  (multiple-value-bind (bol bword eword)
+  (cl-multiple-value-bind (bol bword eword)
       (apples-parse-statement)
     (when eword
       (insert "end " eword)
@@ -994,7 +1004,7 @@ specified, also highlight the matching statement."
         (apples-end-completion-hl bol bword eword)))))
 
 (defun apples-end-completion-hl (bol bword eword)
-  (destructuring-bind ((bov . eov) beg pos)
+  (cl-destructuring-bind ((bov . eov) beg pos)
       (values (apples-plist-get :end-ovs)
               (save-excursion
                 (goto-char bol)
@@ -1195,7 +1205,7 @@ specified, also highlight the matching statement."
                   "Macintosh HD:System:Library:Speech:Voices:"
                   "/System/Library/Speech/Voices/")
                  )))
-          (loop for (folder path posix) in (nreverse lst)
+          (cl-loop for (folder path posix) in (nreverse lst)
                 collect (propertize folder 'path path 'posix posix))))
     )
   "Keywords of AppleScript. Each element has the form (TYPE . KEYWORDS).")
@@ -1271,8 +1281,8 @@ See also `font-lock-defaults' and `font-lock-keywords'.")
           ["Key => Key Code" apples-lookup-key->key-code]
           ["Key Code => Key" apples-lookup-key-code->key])
          ("path to..."
-          ,@(loop for folder in (nreverse (apples-keywords 'standard-folders))
-                  collect (multiple-value-bind (path posix)
+          ,@(cl-loop for folder in (nreverse (apples-keywords 'standard-folders))
+                  collect (cl-multiple-value-bind (path posix)
                               (with-temp-buffer
                                 (insert folder)
                                 (let ((pos (point-min)))
@@ -1302,7 +1312,7 @@ See also `font-lock-defaults' and `font-lock-keywords'.")
   "Set up keybindings for `apples-mode' according to `apples-keymap'."
   (when (and apples-keymap
              (not (apples-plist-get :keybinded?)))
-    (loop for (key . cmd) in apples-keymap
+    (cl-loop for (key . cmd) in apples-keymap
           do (define-key apples-mode-map (read-kbd-macro key) cmd)
           finally (apples-plist-put :keybinded? t))))
 
@@ -1325,7 +1335,7 @@ See also `font-lock-defaults' and `font-lock-keywords'.")
            (?\) ")( 4b")
            (?*  ". 23b")
            )))
-    (loop for (char entry) in lst
+    (cl-loop for (char entry) in lst
           do (modify-syntax-entry char entry st))
     st)
   "Syntax table used in `apples-mode'.")

--- a/apples-mode.el
+++ b/apples-mode.el
@@ -593,7 +593,7 @@ To specify the default query, set `apples-decompile-query'."
   "Send region or current buffer to AppleScript Editor and run it."
   (interactive)
   (ignore-errors
-    (do-applescript
+    (apples-do-applescript
      (apples-encode-string
       (format
        (mapconcat
@@ -665,7 +665,7 @@ To specify the default query, set `apples-decompile-query'."
 (defun apples-open-dict-index ()
   "Open dictionary index in AppleScript Editor."
   (interactive)
-  (do-applescript
+  (apples-do-applescript
    (mapconcat
     'identity
     '("tell application \"AppleScript Editor\" to activate"


### PR DESCRIPTION
The change prevents byte compilation warnings users get when they install the file.